### PR TITLE
Make E2E tests more stable

### DIFF
--- a/e2e/integration/home.test.js
+++ b/e2e/integration/home.test.js
@@ -39,7 +39,7 @@ it("validates the word length input", () => {
 });
 
 it("validates the digits input", () => {
-	cy.getDataQa("digits").clear().type(-2);
+	cy.getDataQa("digits").clear().type(0);
 
 	cy.getDataQa("password").should("contain.text", "No password available");
 	cy.getDataQa("error").should("contain.text", "Number of digits must be positive");


### PR DESCRIPTION
When upgrading Cypress to 3.5, it seems that it can't successfully type -2