### PR TITLE
Fix zero padding

### DIFF
--- a/server/password.js
+++ b/server/password.js
@@ -4,7 +4,7 @@ const SYMBOLS = "!@#$%^&*";
 
 export default (words, digits = 2) => {
 	const [word1, word2] = sample(words, 2);
-	const number = `${randRange(0, 10 ** digits)}`.padStart(2, "0");
+	const number = `${randRange(0, 10 ** digits)}`.padStart(digits, "0");
 	const symbol = choice(SYMBOLS);
 	return `${word1}${number}${word2}${symbol}`;
 };

--- a/server/password.mock.test.js
+++ b/server/password.mock.test.js
@@ -17,4 +17,15 @@ describe("password", () => {
 		expect(randRange).toHaveBeenCalledWith(0, 100);
 		expect(sample).toHaveBeenCalledWith(words, 2);
 	});
+
+	it("pads the non-default length number with zeroes", () => {
+		const words = ["alphabet", "barbaric"];
+		choice.mockReturnValue("!");
+		randRange.mockReturnValue(1);
+		sample.mockReturnValue(words);
+
+		const actual = password(words, 3);
+
+		expect(actual).toBe("alphabet001barbaric!");
+	});
 });


### PR DESCRIPTION
The number of digits padded to is fixed so using a non-default digit count can generate passwords that don't meet requirements.